### PR TITLE
Assignments Group by Course/Due Date

### DIFF
--- a/src/store/modules/work.js
+++ b/src/store/modules/work.js
@@ -40,6 +40,17 @@ const getters = {
 
     return grouped;
   },
+  upcomingAssignmentsGroupedByCourse: state => {
+    const grouped = {};
+
+    for (let a of state.upcomingAssignments) {
+      if (!grouped[a.courseCRN]) grouped[a.courseCRN] = [];
+
+      grouped[a.courseCRN].push(a);
+    }
+
+    return grouped;
+  },
   incompleteUpcomingAssignments: state =>
     state.upcomingAssignments.filter(a => !a.completed),
   getCourseFromCRN: (state, getters, rootState, rootGetters) => crn =>

--- a/src/views/assignments/Assignments.vue
+++ b/src/views/assignments/Assignments.vue
@@ -51,21 +51,19 @@
         </div>
       </div>
       <div class="level-right">
-        <div class="field">
-          <label
-            class="checkbox is-unselectable tooltip"
-            data-tooltip="Toggle completed assignments."
+        <label
+          class="checkbox is-unselectable tooltip"
+          data-tooltip="Toggle completed assignments."
+        >
+          <input
+            v-model="showCompleted"
+            type="checkbox"
           >
-            <input
-              v-model="showCompleted"
-              type="checkbox"
-            >
-            Show Completed
-          </label>
-        </div>
+          Show Completed
+        </label>
         <div
           v-if="view === 'assignments-upcoming'"
-          class="select"
+          class="select group-by-select"
         >
           <select v-model="groupBy">
             <option value="dueDate">
@@ -248,6 +246,10 @@ span.dot.course-dot {
 
 .assignment-controls {
   padding: 10px !important;
+}
+
+.group-by-select {
+  margin-left: 10px;
 }
 
 @media only screen and (max-width: 768px) {

--- a/src/views/assignments/Assignments.vue
+++ b/src/views/assignments/Assignments.vue
@@ -63,6 +63,16 @@
             Show Completed
           </label>
         </div>
+        <div class="select">
+          <select v-model="groupBy">
+            <option value="dueDate">
+              Group by Due Date
+            </option>
+            <option value="course">
+              Group by Course
+            </option>
+          </select>
+        </div>
       </div>
     </div>
     <hr>
@@ -72,6 +82,7 @@
     >
       <router-view
         class="child-view"
+        :group-by="groupBy"
         :show-completed="showCompleted"
         :filter="filter"
         @toggle-assignment="toggleAssignment"
@@ -98,6 +109,7 @@ export default {
   name: 'Assignments',
   data () {
     return {
+      groupBy: 'dueDate',
       showCompleted: true,
       filter: []
     };
@@ -137,7 +149,9 @@ export default {
   mounted () {
     if (localStorage.getItem('assignmentsShowCompleted')) {
       try {
-        this.showCompleted = JSON.parse(localStorage.getItem('assignmentsShowCompleted'));
+        this.showCompleted = JSON.parse(
+          localStorage.getItem('assignmentsShowCompleted')
+        );
       } catch (e) {
         localStorage.removeItem('assignmentsShowCompleted');
       }

--- a/src/views/assignments/Assignments.vue
+++ b/src/views/assignments/Assignments.vue
@@ -147,6 +147,9 @@ export default {
       }
 
       localStorage.setItem('assignmentsShowCompleted', nowShowing);
+    },
+    groupBy (newGroupBy) {
+      localStorage.setItem('assignmentsGroupBy', newGroupBy);
     }
   },
   mounted () {
@@ -157,6 +160,19 @@ export default {
         );
       } catch (e) {
         localStorage.removeItem('assignmentsShowCompleted');
+      }
+    }
+    if (localStorage.getItem('assignmentsGroupBy')) {
+      try {
+        this.groupBy = localStorage.getItem('assignmentsGroupBy');
+        if (this.groupBy !== 'course' && this.groupBy !== 'dueDate') {
+          throw new Error(
+            'Invalid value for assignmentsGroupBy in localStorage'
+          );
+        }
+      } catch (e) {
+        alert(e);
+        localStorage.removeItem('assignmentsGroupBy');
       }
     }
   },

--- a/src/views/assignments/Assignments.vue
+++ b/src/views/assignments/Assignments.vue
@@ -63,7 +63,10 @@
             Show Completed
           </label>
         </div>
-        <div class="select">
+        <div
+          v-if="view === 'assignments-upcoming'"
+          class="select"
+        >
           <select v-model="groupBy">
             <option value="dueDate">
               Group by Due Date

--- a/src/views/assignments/AssignmentsUpcoming.vue
+++ b/src/views/assignments/AssignmentsUpcoming.vue
@@ -19,7 +19,10 @@
         class="column is-one-third-desktop is-half-tablet"
       >
         <div class="panel">
-          <p class="panel-heading is-unselectable key-heading">
+          <p
+            class="panel-heading is-unselectable key-heading"
+            :style="headerStyle(key)"
+          >
             <span
               class="tag is-pulled-right"
               :class="progressClass(key)"
@@ -29,7 +32,7 @@
             </span>
             <span
               class="key"
-              :title="headerTitle(key)"
+              :title="headerTitle"
               @click="headerClick(key)"
             >
               {{ headerText(key) }}
@@ -115,6 +118,9 @@ export default {
     none () {
       return Object.keys(this.filtered).length === 0;
     },
+    headerTitle () {
+      return this.groupBy === 'course' ? 'Open course modal.' : 'Add assignment to this day.';
+    },
     filtered () {
       const filtered = {};
       for (let key in this.groupedAssignments) {
@@ -146,8 +152,13 @@ export default {
     headerText (key) {
       return this.groupBy === 'course' ? this.course(key).longname : this.toDateShortString(key);
     },
-    headerTitle (key) {
-      return this.groupBy === 'course' ? 'Open course modal.' : 'Add assignment to this day.';
+    headerStyle (key) {
+      if (this.groupBy === 'dueDate') return {};
+      let color = this.course(key).color;
+      if (color.length < 5) {
+        color += color.slice(1);
+      }
+      return { 'background-color': this.groupBy === 'course' ? this.course(key).color : 'inherit', color: (color.replace('#', '0x')) > (0xffffff / 1.2) ? '#333' : '#fff' };
     },
     headerClick (key) {
       if (this.groupBy === 'course') {
@@ -204,7 +215,7 @@ export default {
 
 <style lang="scss" scoped>
 .key-heading {
-  span {
+  span.key {
     cursor: pointer;
   }
 }

--- a/src/views/assignments/AssignmentsUpcoming.vue
+++ b/src/views/assignments/AssignmentsUpcoming.vue
@@ -28,7 +28,11 @@
               >
                 {{ percentDone(crn) }}%
               </span>
-              <span class="date">
+              <span
+                class="crn"
+                title="Click to open course modal."
+                @click="$store.commit('OPEN_COURSE_MODAL', course(crn))"
+              >
                 {{ course(crn).longname }}
               </span>
             </p>
@@ -84,10 +88,7 @@
           class="due-date column is-one-third-desktop is-half-tablet"
         >
           <div class="panel">
-            <p
-              class="panel-heading tooltip is-tooltip-bottom is-unselectable date-heading"
-              :data-tooltip="daysAway(date) + ' days away'"
-            >
+            <p class="panel-heading is-unselectable date-heading">
               <span
                 class="tag is-pulled-right"
                 :class="progressClass(date)"
@@ -95,7 +96,11 @@
               >
                 {{ percentDone(date) }}%
               </span>
-              <span class="date">
+              <span
+                title="Click to add an assignment to this day."
+                class="date"
+                @click="clickDateHeading(date)"
+              >
                 {{ toDateShortString(date) }}
               </span>
             </p>
@@ -198,6 +203,10 @@ export default {
     course (crn) {
       return this.$store.getters.getCourseFromCRN(crn);
     },
+    clickDateHeading (date) {
+      this.$store.commit('SET_ADD_ASSIGNMENT_MODAL_DUE_DATE', moment(date));
+      this.$store.commit('TOGGLE_ADD_ASSIGNMENT_MODAL');
+    },
     toggleAssignmentTitle (a) {
       return (
         this.course(a.courseCRN).longname +
@@ -240,6 +249,12 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+.course-heading,
+.date-heading {
+  span {
+    cursor: pointer;
+  }
+}
 .assignment {
   padding-right: 5px;
   padding-left: 5px;

--- a/src/views/assignments/AssignmentsUpcoming.vue
+++ b/src/views/assignments/AssignmentsUpcoming.vue
@@ -13,68 +13,134 @@
       v-else
       class="columns is-multiline"
     >
-      <div
-        v-for="(assignments, date) in filtered"
-        :key="date"
-        class="due-date column is-one-third-desktop is-half-tablet"
-      >
-        <div class="panel">
-          <p
-            class="panel-heading tooltip is-tooltip-bottom is-unselectable date-heading"
-            :data-tooltip="daysAway(date) + ' days away'"
-          >
-            <span
-              class="tag is-pulled-right"
-              :class="progressClass(date)"
-              :title="`You are ${percentDone(date)}% complete with this day's assignments.`"
+      <template v-if="groupBy === 'course'">
+        <div
+          v-for="(assignments, crn) in filtered"
+          :key="crn"
+          class="due-date column is-one-third-desktop is-half-tablet"
+        >
+          <div class="panel">
+            <p class="panel-heading is-unselectable course-heading">
+              <span
+                class="tag is-pulled-right"
+                :class="progressClass(crn)"
+                :title="`You are ${percentDone(crn)}% complete with this course's assignments.`"
+              >
+                {{ percentDone(crn) }}%
+              </span>
+              <span class="date">
+                {{ course(crn).longname }}
+              </span>
+            </p>
+            <div
+              v-for="a in assignments"
+              :key="a._id"
+              class="panel-block assignment"
             >
-              {{ percentDone(date) }}%
-            </span>
-            <span class="date">
-              {{ toDateShortString(date) }}
-            </span>
-          </p>
-          <div
-            v-for="a in assignments"
-            :key="a._id"
-            class="panel-block assignment"
-          >
-            <span class="is-full-width">
-              <span
-                class="icon toggle-assignment"
-                @click="$emit('toggle-assignment', a._id)"
-              >
+              <span class="is-full-width">
                 <span
-                  :class="{ 'fas fa-check-circle': a.completed, 'far fa-circle': !a.completed }"
-                  :title="toggleAssignmentTitle(a)"
-                  :style="{ 'color': course(a).color }"
-                />
+                  class="icon toggle-assignment"
+                  @click="$emit('toggle-assignment', a._id)"
+                >
+                  <span
+                    :class="{ 'fas fa-check-circle': a.completed, 'far fa-circle': !a.completed }"
+                    :title="toggleAssignmentTitle(a)"
+                    :style="{ 'color': course(a.courseCRN).color }"
+                  />
+                </span>
+                <router-link
+                  class="assignment-link"
+                  :title="(a.priority === 1 ? '(OPTIONAL) ' : '') + a.description.substring(0, 500)"
+                  :to="{ name: 'assignments-overview', params: { assignmentID: a._id }}"
+                  :class="{ 'priority': a.priority > 3, 'has-text-grey is-italic': a.priority === 1 }"
+                >
+                  <b class="course-title is-hidden-tablet">
+                    {{ course(a.courseCRN).longname }}
+                  </b>
+                  {{ a.title }}
+                </router-link>
+                <span
+                  :style="{visibility: a.completed || a.fullyScheduled ? 'hidden' : ''}"
+                  class="tooltip is-tooltip-left icon has-text-danger is-pulled-right"
+                  :data-tooltip="`You've only scheduled ${a.scheduledTime} out of ${a.timeEstimate * 60} min to work on this.`"
+                >
+                  <i class="far fa-clock" />
+                </span>
+                <small
+                  class="is-pulled-right tooltip is-tooltip-left has-text-grey"
+                  :data-tooltip="toDateShortString(a.dueDate) + ' ' + toTimeString(a.dueDate)"
+                >
+                  {{ fromNow(a.dueDate) }}
+                </small>
               </span>
-              <router-link
-                class="assignment-link"
-                :title="(a.priority === 1 ? '(OPTIONAL) ' : '') + a.description.substring(0, 500)"
-                :to="{ name: 'assignments-overview', params: { assignmentID: a._id }}"
-                :class="{ 'priority': a.priority > 3, 'has-text-grey is-italic': a.priority === 1 }"
-              >
-                <b class="course-title is-hidden-tablet">
-                  {{ course(a).longname }}
-                </b>
-                {{ a.title }}
-              </router-link>
-              <span
-                :style="{visibility: a.completed || a.fullyScheduled ? 'hidden' : ''}"
-                class="tooltip is-tooltip-left icon has-text-danger is-pulled-right"
-                :data-tooltip="`You've only scheduled ${a.scheduledTime} out of ${a.timeEstimate * 60} min to work on this.`"
-              >
-                <i class="far fa-clock" />
-              </span>
-              <small class="is-pulled-right has-text-grey">
-                {{ toTimeString(a.dueDate) }}
-              </small>
-            </span>
+            </div>
           </div>
         </div>
-      </div>
+      </template>
+      <template v-else>
+        <div
+          v-for="(assignments, date) in filtered"
+          :key="date"
+          class="due-date column is-one-third-desktop is-half-tablet"
+        >
+          <div class="panel">
+            <p
+              class="panel-heading tooltip is-tooltip-bottom is-unselectable date-heading"
+              :data-tooltip="daysAway(date) + ' days away'"
+            >
+              <span
+                class="tag is-pulled-right"
+                :class="progressClass(date)"
+                :title="`You are ${percentDone(date)}% complete with this day's assignments.`"
+              >
+                {{ percentDone(date) }}%
+              </span>
+              <span class="date">
+                {{ toDateShortString(date) }}
+              </span>
+            </p>
+            <div
+              v-for="a in assignments"
+              :key="a._id"
+              class="panel-block assignment"
+            >
+              <span class="is-full-width">
+                <span
+                  class="icon toggle-assignment"
+                  @click="$emit('toggle-assignment', a._id)"
+                >
+                  <span
+                    :class="{ 'fas fa-check-circle': a.completed, 'far fa-circle': !a.completed }"
+                    :title="toggleAssignmentTitle(a)"
+                    :style="{ 'color': course(a.courseCRN).color }"
+                  />
+                </span>
+                <router-link
+                  class="assignment-link"
+                  :title="(a.priority === 1 ? '(OPTIONAL) ' : '') + a.description.substring(0, 500)"
+                  :to="{ name: 'assignments-overview', params: { assignmentID: a._id }}"
+                  :class="{ 'priority': a.priority > 3, 'has-text-grey is-italic': a.priority === 1 }"
+                >
+                  <b class="course-title is-hidden-tablet">
+                    {{ course(a.courseCRN).longname }}
+                  </b>
+                  {{ a.title }}
+                </router-link>
+                <span
+                  :style="{visibility: a.completed || a.fullyScheduled ? 'hidden' : ''}"
+                  class="tooltip is-tooltip-left icon has-text-danger is-pulled-right"
+                  :data-tooltip="`You've only scheduled ${a.scheduledTime} out of ${a.timeEstimate * 60} min to work on this.`"
+                >
+                  <i class="far fa-clock" />
+                </span>
+                <small class="is-pulled-right has-text-grey">
+                  {{ toTimeString(a.dueDate) }}
+                </small>
+              </span>
+            </div>
+          </div>
+        </div>
+      </template>
     </div>
   </div>
 </template>
@@ -87,6 +153,10 @@ export default {
     showCompleted: {
       type: Boolean,
       default: true
+    },
+    groupBy: {
+      type: String,
+      required: true
     },
     filter: {
       type: Array,
@@ -102,42 +172,48 @@ export default {
     },
     filtered () {
       const filtered = {};
-      for (let date in this.upcomingAssignmentsGroupedByDueDate) {
-        filtered[date] = this.upcomingAssignmentsGroupedByDueDate[date].filter(
-          a => {
-            if (!this.showCompleted && a.completed) return false;
-            return !this.filter.includes(this.course(a).crn);
-          }
-        );
-        if (filtered[date].length === 0) delete filtered[date];
+      for (let key in this.groupedAssignments) {
+        filtered[key] = this.groupedAssignments[key].filter(a => {
+          if (!this.showCompleted && a.completed) return false;
+          return !this.filter.includes(this.course(a.crn));
+        });
+        if (filtered[key].length === 0) delete filtered[key];
       }
 
       return filtered;
     },
+    groupedAssignments () {
+      return this.groupBy === 'course'
+        ? this.upcomingAssignmentsGroupedByCourse
+        : this.upcomingAssignmentsGroupedByDueDate;
+    },
     upcomingAssignmentsGroupedByDueDate () {
       return this.$store.getters.upcomingAssignmentsGroupedByDueDate;
+    },
+    upcomingAssignmentsGroupedByCourse () {
+      return this.$store.getters.upcomingAssignmentsGroupedByCourse;
     }
   },
   methods: {
-    course (a) {
-      return this.$store.getters.getCourseFromCRN(a.courseCRN);
+    course (crn) {
+      return this.$store.getters.getCourseFromCRN(crn);
     },
     toggleAssignmentTitle (a) {
       return (
-        this.course(a).longname +
+        this.course(a.courseCRN).longname +
         (a.completedAt
           ? ` | Completed ${moment(a.completedAt).format('M/DD/YY h:mma')}`
           : '')
       );
     },
-    percentDone (date) {
-      const assignments = this.upcomingAssignmentsGroupedByDueDate[date];
+    percentDone (key) {
+      const assignments = this.groupedAssignments[key];
       return Math.round(
         (assignments.filter(a => a.completed).length / assignments.length) * 100
       );
     },
-    progressClass (date) {
-      const percentDone = this.percentDone(date);
+    progressClass (key) {
+      const percentDone = this.percentDone(key);
       if (percentDone === 100) return 'is-success';
       if (percentDone >= 50) return 'is-warning';
       if (percentDone > 0) return 'is-danger';
@@ -152,6 +228,9 @@ export default {
     },
     toTimeString (dueDate) {
       return moment(dueDate).format('h:mma');
+    },
+    fromNow (date) {
+      return moment(date).fromNow();
     },
     daysAway (date) {
       return moment(date).diff(moment(this.now).startOf('day'), 'days');


### PR DESCRIPTION
Fixes issue #223 

## Proposed Changes
- AssignmentsUpcoming has select input with 'course' or 'dueDate'
- either display upcoming assignments grouped by due date or grouped by course
- choice saved to localStorage