### PR TITLE
Added pagination, filtering, and searching to the user list

### DIFF
--- a/server/api/courses/courses.controller.js
+++ b/server/api/courses/courses.controller.js
@@ -10,7 +10,7 @@ async function getCourses (ctx) {
   const courses = await Course.find({
     _student: ctx.state.user._id,
     termCode: ctx.session.currentTerm.code
-  }).sort('title')
+  }).sort('-credits title')
 
   return ctx.ok({ courses })
 }
@@ -20,7 +20,7 @@ async function getTermCourses (ctx) {
   const courses = await Course.find({
     _student: ctx.state.user._id,
     termCode
-  }).sort('title')
+  }).sort('-credits title')
 
   logger.info(`Sending term ${termCode} courses to ${ctx.state.user.rcs_id}`)
 

--- a/server/api/courses/courses.controller.js
+++ b/server/api/courses/courses.controller.js
@@ -10,7 +10,7 @@ async function getCourses (ctx) {
   const courses = await Course.find({
     _student: ctx.state.user._id,
     termCode: ctx.session.currentTerm.code
-  }).sort('originalTitle')
+  }).sort('title')
 
   return ctx.ok({ courses })
 }
@@ -20,7 +20,7 @@ async function getTermCourses (ctx) {
   const courses = await Course.find({
     _student: ctx.state.user._id,
     termCode
-  }).sort('originalTitle')
+  }).sort('title')
 
   logger.info(`Sending term ${termCode} courses to ${ctx.state.user.rcs_id}`)
 

--- a/server/api/students/students.controller.js
+++ b/server/api/students/students.controller.js
@@ -97,6 +97,7 @@ function formSearchObject (str) {
   // Form regex for the name/rcs id searching
   let regexStr = '.*'
   regexStr += str
+    .replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // https://stackoverflow.com/a/6969486
     .replace(/ +/g, ' ') // Remove duplicate spaces
     .replace(' ', '|') // Convert each space into OR
   regexStr += '.*'

--- a/server/api/students/students.controller.js
+++ b/server/api/students/students.controller.js
@@ -142,7 +142,7 @@ function checkForLockedFilter (str) {
   const filter = {}
   let matchResult
   while ((matchResult = str.match(lockedFilter)) !== null) {
-    filter.admin = !(matchResult[1]) // Negate if there exists an ! in the search term
+    filter.accountLocked = !(matchResult[1]) // Negate if there exists an ! in the search term
     str = str.replace(lockedFilter, '')
   }
   return { filter, str }

--- a/server/api/students/students.controller.js
+++ b/server/api/students/students.controller.js
@@ -107,7 +107,7 @@ function formSearchObject (str) {
     { 'name.preferred': regex },
     { 'name.last': regex },
     { rcs_id: regex }
-  ] }, filterResults.filters)
+  ] }, filter)
 }
 
 /**

--- a/server/api/students/students.controller.js
+++ b/server/api/students/students.controller.js
@@ -56,7 +56,7 @@ async function getUser (ctx) {
  */
 async function getStudents (ctx) {
   const page = parseInt(ctx.query.page) || 0
-  const itemsPerPage = parseInt(ctx.query.itemsPerPage) || 20
+  const itemsPerPage = parseInt(ctx.query.itemsPerPage) || 25
 
   if (!ctx.state.user.admin) {
     return ctx.forbidden('You are not an administrator!')

--- a/server/api/students/students.controller.js
+++ b/server/api/students/students.controller.js
@@ -55,14 +55,14 @@ async function getUser (ctx) {
  * @param {Koa context} ctx
  */
 async function getStudents (ctx) {
-  const page = parseInt(ctx.query.page) || 0
+  const page = parseInt(ctx.query.page) || 1
   const itemsPerPage = parseInt(ctx.query.itemsPerPage) || 25
 
   if (!ctx.state.user.admin) {
     return ctx.forbidden('You are not an administrator!')
   }
 
-  const students = await Student.find().sort('rcs_id').skip(page * itemsPerPage).limit(itemsPerPage)
+  const students = await Student.find().sort('rcs_id').skip((page - 1) * itemsPerPage).limit(itemsPerPage)
   const studentCount = await Student.count()
   ctx.ok({ students, studentCount })
 }

--- a/server/api/students/students.controller.js
+++ b/server/api/students/students.controller.js
@@ -55,12 +55,16 @@ async function getUser (ctx) {
  * @param {Koa context} ctx
  */
 async function getStudents (ctx) {
+  const page = parseInt(ctx.query.page) || 0
+  const itemsPerPage = parseInt(ctx.query.itemsPerPage) || 20
+
   if (!ctx.state.user.admin) {
     return ctx.forbidden('You are not an administrator!')
   }
 
-  const students = await Student.find()
-  ctx.ok({ students })
+  const students = await Student.find().sort('rcs_id').skip(page * itemsPerPage).limit(itemsPerPage)
+  const studentCount = await Student.count()
+  ctx.ok({ students, studentCount })
 }
 
 /**

--- a/src/router.js
+++ b/src/router.js
@@ -357,10 +357,14 @@ const router = new Router({
       children: [
         {
           path: '',
-          redirect: 'students'
+          redirect: 'students/1'
         },
         {
           path: 'students',
+          redirect: 'students/1'
+        },
+        {
+          path: 'students/:page',
           name: 'admin-student-list',
           meta: {
             title: 'Students'

--- a/src/views/admin/TheAdminPage.vue
+++ b/src/views/admin/TheAdminPage.vue
@@ -16,7 +16,7 @@
           Administration
         </h1>
         <router-link
-          :to="{name: 'admin-student-list'}"
+          :to="{name: 'admin-student-list', params: {page: 1}}"
           tag="li"
         >
           <a>Students</a>

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -17,45 +17,14 @@
       </small>
     </h2>
 
-    <div class="has-text-grey block">
-      <div class="is-pulled-right">
-        <b-button
-          @click="prevPage"
-        >
-          &lt;&lt;
-        </b-button>
-        Page {{ page + 1 }} of {{ pageCount }}
-        <b-button
-          @click="nextPage"
-        >
-          &gt;&gt;
-        </b-button>
-      </div>
-      <div>
-        <span>Items per page: </span>
-        <b-select
-          v-model="itemsPerPage"
-          class="pagination-item-dropdown"
-          @input="getPageContents"
-        >
-          <option value="10">
-            10
-          </option>
-          <option value="25">
-            25
-          </option>
-          <option value="50">
-            50
-          </option>
-          <option value="200">
-            200
-          </option>
-          <option value="1000">
-            1000
-          </option>
-        </b-select>
-      </div>
-    </div>
+    <AdminStudentListPagination
+      :total-items="studentCount"
+      :per-page="parseInt(itemsPerPage)"
+      :current-page="page"
+      class="block"
+      @change-item-count="changeItemPerPageCount"
+      @go-to-page="goToPage"
+    />
 
     <b-table
       ref="table"
@@ -110,61 +79,31 @@
       </template>
     </b-table>
 
-    <div class="has-text-grey block">
-      <div class="is-pulled-right">
-        <b-button
-          @click="prevPage"
-        >
-          &lt;&lt;
-        </b-button>
-        Page {{ page + 1 }} of {{ pageCount }}
-        <b-button
-          @click="nextPage"
-        >
-          &gt;&gt;
-        </b-button>
-      </div>
-      <div>
-        <span>Items per page: </span>
-        <b-select
-          v-model="itemsPerPage"
-          class="pagination-item-dropdown"
-          @input="getPageContents"
-        >
-          <option value="10">
-            10
-          </option>
-          <option value="25">
-            25
-          </option>
-          <option value="50">
-            50
-          </option>
-          <option value="200">
-            200
-          </option>
-          <option value="1000">
-            1000
-          </option>
-        </b-select>
-      </div>
-    </div>
+    <AdminStudentListPagination
+      :total-items="studentCount"
+      :per-page="parseInt(itemsPerPage)"
+      :current-page="page"
+      class="block"
+      @change-item-count="changeItemPerPageCount"
+      @go-to-page="goToPage"
+    />
   </div>
 </template>
 
 <script>
 import AdminStudentListOverview from '@/views/admin/components/AdminStudentListOverview.vue'
+import AdminStudentListPagination from '@/views/admin/components/AdminStudentListPagination.vue'
 export default {
   name: 'AdminStudentList',
-  components: { AdminStudentListOverview },
+  components: { AdminStudentListOverview, AdminStudentListPagination },
   data () {
     return {
       loading: true,
       studentsOnPage: [],
       studentCount: 0,
-      page: 0,
+      page: 1,
       itemsPerPage: 25,
-      pageCount: 0
+      pageCount: 1
     }
   },
   async created () {
@@ -199,30 +138,15 @@ export default {
       this.studentCount = request.data.studentCount
       this.pageCount = Math.ceil(this.studentCount / this.itemsPerPage)
 
-      // This can occur when the user changes the number of items
-      // per page while they are not on the first page. Re-fetch required.
-      if (this.page + 1 > this.pageCount) {
-        this.page = this.pageCount - 1
-        this.getPageContents()
-      }
-
       this.loading = false
     },
-    async nextPage () {
-      if (this.page + 1 >= this.pageCount) {
-        return
-      }
-
-      this.page++
-      return this.getPageContents()
+    async changeItemPerPageCount (count) {
+      this.itemsPerPage = count // fixme - See comment in AdminStudentListPagination
+      this.getPageContents()
     },
-    async prevPage () {
-      if (this.page <= 0) {
-        return
-      }
-
-      this.page--
-      return this.getPageContents()
+    async goToPage (page) {
+      this.page = page // fixme - See comment in AdminStudentListPagination
+      this.getPageContents()
     },
     updatedStudent (student) {
       Object.assign(this.studentsOnPage.find(s => s._id === student._id), student)
@@ -235,7 +159,4 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .pagination-item-dropdown {
-    display: inline;
-  }
 </style>

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -2,7 +2,7 @@
 <template>
   <div class="admin-user-list">
     <b-loading
-      :is-full-page="false"
+      :is-full-page="true"
       :active="loading"
       :can-cancel="false"
     />

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -17,18 +17,44 @@
       </small>
     </h2>
 
-    <div class="is-pulled-right has-text-grey">
-      <b-button
-        @click="prevPage"
-      >
-        &lt;&lt;
-      </b-button>
-      Page {{ page + 1 }} of {{ pageCount }}
-      <b-button
-        @click="nextPage"
-      >
-        &gt;&gt;
-      </b-button>
+    <div class="has-text-grey block">
+      <div class="is-pulled-right">
+        <b-button
+          @click="prevPage"
+        >
+          &lt;&lt;
+        </b-button>
+        Page {{ page + 1 }} of {{ pageCount }}
+        <b-button
+          @click="nextPage"
+        >
+          &gt;&gt;
+        </b-button>
+      </div>
+      <div>
+        <span>Items per page: </span>
+        <b-select
+          v-model="itemsPerPage"
+          class="pagination-item-dropdown"
+          @input="getPageContents"
+        >
+          <option value="10">
+            10
+          </option>
+          <option value="25">
+            25
+          </option>
+          <option value="50">
+            50
+          </option>
+          <option value="200">
+            200
+          </option>
+          <option value="1000">
+            1000
+          </option>
+        </b-select>
+      </div>
     </div>
 
     <b-table
@@ -37,6 +63,7 @@
       detailed
       detail-key="rcs_id"
       :row-class="rowClass"
+      class="clear-float-right block"
     >
       <template slot-scope="props">
         <b-table-column
@@ -83,18 +110,44 @@
       </template>
     </b-table>
 
-    <div class="is-pulled-right has-text-grey">
-      <b-button
-        @click="prevPage"
-      >
-        &lt;&lt;
-      </b-button>
-      Page {{ page + 1 }} of {{ pageCount }}
-      <b-button
-        @click="nextPage"
-      >
-        &gt;&gt;
-      </b-button>
+    <div class="has-text-grey block">
+      <div class="is-pulled-right">
+        <b-button
+          @click="prevPage"
+        >
+          &lt;&lt;
+        </b-button>
+        Page {{ page + 1 }} of {{ pageCount }}
+        <b-button
+          @click="nextPage"
+        >
+          &gt;&gt;
+        </b-button>
+      </div>
+      <div>
+        <span>Items per page: </span>
+        <b-select
+          v-model="itemsPerPage"
+          class="pagination-item-dropdown"
+          @input="getPageContents"
+        >
+          <option value="10">
+            10
+          </option>
+          <option value="25">
+            25
+          </option>
+          <option value="50">
+            50
+          </option>
+          <option value="200">
+            200
+          </option>
+          <option value="1000">
+            1000
+          </option>
+        </b-select>
+      </div>
     </div>
   </div>
 </template>
@@ -110,7 +163,7 @@ export default {
       studentsOnPage: [],
       studentCount: 0,
       page: 0,
-      itemsPerPage: 20,
+      itemsPerPage: 25,
       pageCount: 0
     }
   },
@@ -145,6 +198,14 @@ export default {
       this.studentsOnPage = request.data.students
       this.studentCount = request.data.studentCount
       this.pageCount = Math.ceil(this.studentCount / this.itemsPerPage)
+
+      // This can occur when the user changes the number of items
+      // per page while they are not on the first page. Re-fetch required.
+      if (this.page + 1 > this.pageCount) {
+        this.page = this.pageCount - 1
+        this.getPageContents()
+      }
+
       this.loading = false
     },
     async nextPage () {
@@ -174,4 +235,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  .pagination-item-dropdown {
+    display: inline;
+  }
 </style>

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -173,7 +173,7 @@ export default {
 
       this.studentsOnPage = request.data.students
       this.studentCount = request.data.studentCount
-      this.pageCount = Math.ceil(this.studentCount / this.itemsPerPage)
+      this.pageCount = Math.max(Math.ceil(this.studentCount / this.itemsPerPage), 1)
 
       this.loading = false
     },
@@ -211,7 +211,7 @@ export default {
      * @returns {Promise<void>}
      */
     async goToPage (page) {
-      this.page = page
+      this.page = Math.max(page, 1)
       await this.$router.push({ name: 'admin-student-list', params: { page: this.page }, query: this.$route.query })
       this.getPageContents()
     },

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -25,13 +25,29 @@
       @change-item-count="changeItemPerPageCount"
       @go-to-page="goToPage"
     />
-    <b-input
-      v-model="searchTerm"
-      type="text"
-      placeholder="Search"
-      class="block"
-      @input="searchChanged"
-    />
+    <b-field grouped>
+      <b-input
+        v-model="searchTerm"
+        type="text"
+        placeholder="Search..."
+        class="block"
+        expanded
+        icon="search"
+        @input="searchChanged"
+      />
+      <b-tooltip
+        :label="getSearchTooltip()"
+        class="search-tooltip"
+        multilined
+        animated
+        type="is-dark"
+        position="is-left"
+      >
+        <b-button
+          icon-right="question"
+        />
+      </b-tooltip>
+    </b-field>
 
     <b-table
       ref="table"
@@ -102,7 +118,7 @@ import AdminStudentListOverview from '@/views/admin/components/AdminStudentListO
 import AdminStudentListPagination from '@/views/admin/components/AdminStudentListPagination.vue'
 
 const defaultItemsPerPage = 25
-const requiredTimeBeforeSearch = 500 // Number of ms required without change in the search before executing the search
+const requiredTimeBeforeSearch = 300 // Number of ms required without change in the search before executing the search
 
 export default {
   name: 'AdminStudentList',
@@ -225,6 +241,17 @@ export default {
       }, requiredTimeBeforeSearch)
     },
     /**
+     * Get the contents to be displayed in the tooltip next to the search bar
+     */
+    getSearchTooltip () {
+      return 'Available filters:\n' +
+        'is:admin\n' +
+        'is:locked\n' +
+        'year:####\n' +
+        '\n' +
+        'Prepend ! to negate any filter.'
+    },
+    /**
      * Searches the list of students for a student object with the same ID. Once found,
      * that object is updated/replaced with the new student object, which should be
      * considered to have more up-to-date information.
@@ -248,4 +275,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+  .search-tooltip.b-tooltip:after { /* Allows line breaks in tooltip */
+    white-space: pre;
+  }
 </style>

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -12,7 +12,7 @@
         {{ studentCount }} total
         <b-button
           :loading="loading"
-          @click="getStudents"
+          @click="getPageContents"
         >Refresh</b-button>
       </small>
     </h2>
@@ -33,7 +33,7 @@
 
     <b-table
       ref="table"
-      :data="students"
+      :data="studentsOnPage"
       detailed
       detail-key="rcs_id"
       :row-class="rowClass"
@@ -107,9 +107,7 @@ export default {
   data () {
     return {
       loading: true,
-      sortBy: 'rcs_id',
-      sortAscending: true,
-      students: [],
+      studentsOnPage: [],
       studentCount: 0,
       page: 0,
       itemsPerPage: 20,
@@ -117,7 +115,7 @@ export default {
     }
   },
   async created () {
-    await this.getStudents()
+    await this.getPageContents()
   },
   methods: {
     toggle (row) {
@@ -127,7 +125,7 @@ export default {
       if (row.admin) return 'has-background-primary'
       if (row.accountLocked) return 'has-background-warning'
     },
-    async getStudents () {
+    async getPageContents () {
       this.loading = true
       let request
       try {
@@ -139,12 +137,12 @@ export default {
           message: e.response.data.message,
           type: 'is-danger'
         })
-        this.students = []
+        this.studentsOnPage = []
         this.loading = false
         return
       }
 
-      this.students = request.data.students
+      this.studentsOnPage = request.data.students
       this.studentCount = request.data.studentCount
       this.pageCount = Math.ceil(this.studentCount / this.itemsPerPage)
       this.loading = false
@@ -155,7 +153,7 @@ export default {
       }
 
       this.page++
-      return this.getStudents()
+      return this.getPageContents()
     },
     async prevPage () {
       if (this.page <= 0) {
@@ -163,13 +161,13 @@ export default {
       }
 
       this.page--
-      return this.getStudents()
+      return this.getPageContents()
     },
     updatedStudent (student) {
-      Object.assign(this.students.find(s => s._id === student._id), student)
+      Object.assign(this.studentsOnPage.find(s => s._id === student._id), student)
     },
     deletedStudent (studentID) {
-      this.students = this.students.filter(s => s._id !== studentID)
+      this.studentsOnPage = this.studentsOnPage.filter(s => s._id !== studentID)
     }
   }
 }

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -33,6 +33,7 @@
         class="block"
         expanded
         icon="search"
+        maxlength="1000"
         @input="searchChanged"
       />
       <b-tooltip

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -23,7 +23,7 @@
       >
         &lt;&lt;
       </b-button>
-      Page {{ page + 1 }} of {{ Math.ceil(studentCount / itemsPerPage) }}
+      Page {{ page + 1 }} of {{ pageCount }}
       <b-button
         @click="nextPage"
       >
@@ -89,7 +89,7 @@
       >
         &lt;&lt;
       </b-button>
-      Page {{ page + 1 }} of {{ Math.ceil(studentCount / itemsPerPage) }}
+      Page {{ page + 1 }} of {{ pageCount }}
       <b-button
         @click="nextPage"
       >
@@ -112,7 +112,8 @@ export default {
       students: [],
       studentCount: 0,
       page: 0,
-      itemsPerPage: 20
+      itemsPerPage: 20,
+      pageCount: 0
     }
   },
   async created () {
@@ -145,13 +146,22 @@ export default {
 
       this.students = request.data.students
       this.studentCount = request.data.studentCount
+      this.pageCount = Math.ceil(this.studentCount / this.itemsPerPage)
       this.loading = false
     },
     async nextPage () {
+      if (this.page + 1 >= this.pageCount) {
+        return
+      }
+
       this.page++
       return this.getStudents()
     },
     async prevPage () {
+      if (this.page <= 0) {
+        return
+      }
+
       this.page--
       return this.getStudents()
     },

--- a/src/views/admin/components/AdminStudentList.vue
+++ b/src/views/admin/components/AdminStudentList.vue
@@ -183,7 +183,6 @@ export default {
      * was previously at the top of the list. This method will also alter the route
      * to contain the new count in the query string. Once changed, the table will be
      * re-rendered.
-     * fixme - See comment in AdminStudentListPagination
      * @param count {number} Number of items that should exist per page. Should be
      * an integer greater than or equal to 1.
      * @returns {Promise<void>}
@@ -205,7 +204,6 @@ export default {
      * Switch the currently displayed page in the user list to the page provided. This
      * method will also alter the current route to the new page number. Once changed,
      * the table will be re-rendered.
-     * fixme - See comment in AdminStudentListPagination
      * @param page {number} The page to switch to. Should be an integer greater than or
      * equal to 1.
      * @returns {Promise<void>}

--- a/src/views/admin/components/AdminStudentListPagination.vue
+++ b/src/views/admin/components/AdminStudentListPagination.vue
@@ -46,13 +46,7 @@ export default {
     perPage: { type: Number, required: true },
     currentPage: { type: Number, required: true } },
   data () {
-    return {
-      /* FIXME My understanding is it's bad practice to use props directly as it causes them to mutate, however
-          I can't seem to get this component to rerender if I update via $emit/events in parent - Erik
-       */
-      // perPageLocal: Math.ceil(Math.max(1, this.perPage)),
-      // currentPageLocal: Math.ceil(Math.max(1, Math.min(this.totalItems / this.perPage, this.currentPage)))
-    }
+    return {}
   },
   methods: {
     async goToPage (page) {

--- a/src/views/admin/components/AdminStudentListPagination.vue
+++ b/src/views/admin/components/AdminStudentListPagination.vue
@@ -1,0 +1,69 @@
+<template>
+  <section>
+    <div class="block">
+      <span>Items per page: </span>
+      <b-select
+        v-model="perPage"
+        @input="changeItemCount"
+      >
+        <option value="10">
+          10
+        </option>
+        <option value="25">
+          25
+        </option>
+        <option value="50">
+          50
+        </option>
+        <option value="200">
+          200
+        </option>
+        <option value="1000">
+          1000
+        </option>
+      </b-select>
+    </div>
+    <b-pagination
+      :total="totalItems"
+      :current.sync="currentPage"
+      :range-before="2"
+      :range-after="2"
+      :per-page="perPage"
+      aria-next-label="Next page"
+      aria-previous-label="Previous page"
+      aria-page-label="Page"
+      aria-current-label="Current page"
+      @change="goToPage"
+    />
+  </section>
+</template>
+
+<script>
+export default {
+
+  name: 'AdminStudentListPagination',
+  props: { totalItems: { type: Number, required: true },
+    perPage: { type: Number, required: true },
+    currentPage: { type: Number, required: true } },
+  data () {
+    return {
+      /* FIXME My understanding is it's bad practice to use props directly as it causes them to mutate, however
+          I can't seem to get this component to rerender if I update via $emit/events in parent - Erik
+       */
+      // perPageLocal: Math.ceil(Math.max(1, this.perPage)),
+      // currentPageLocal: Math.ceil(Math.max(1, Math.min(this.totalItems / this.perPage, this.currentPage)))
+    }
+  },
+  methods: {
+    async goToPage (page) {
+      this.$emit('go-to-page', page)
+    },
+    async changeItemCount (count) {
+      this.$emit('change-item-count', count)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+</style>

--- a/src/views/admin/components/AdminStudentListPagination.vue
+++ b/src/views/admin/components/AdminStudentListPagination.vue
@@ -26,8 +26,8 @@
     <b-pagination
       :total="totalItems"
       :current.sync="currentPage"
-      :range-before="2"
-      :range-after="2"
+      :range-before="1"
+      :range-after="1"
       :per-page="perPage"
       aria-next-label="Next page"
       aria-previous-label="Previous page"

--- a/src/views/components/TheHeader.vue
+++ b/src/views/components/TheHeader.vue
@@ -247,7 +247,7 @@
           <b-navbar-item
             v-if="user.admin"
             tag="router-link"
-            :to="{name: 'admin-student-list'}"
+            :to="{name: 'admin-student-list', params: {page: 1}}"
             title="View the administrator page"
           >
             <span class="icon">


### PR DESCRIPTION
Fixes issue #395

## Proposed Changes
- **Pagination of users, default of 25 users per page.**
  - Number of users per page can be changed with a dropdown
- **Search users for a specific name or RCS ID.**
  - Just checks for a `.*UserSearch.*` regex match in the database.
  - Multiple searches allowed at once by separating with spaces.
- **Filter users based off of their graduation year and whether they are admin and/or locked.**
  - Filters simply go in the search bar, with the proper syntax
    - Hover over the question mark next to the search bar for syntax
  - Multiple filters are allowed at once by separating with spaces
- **All data is persistent through reload through path params and querystrings**