### PR TITLE
Fixed bug causing the sidebar to not appear at all

### DIFF
--- a/src/views/sidebar/components/TheSidebar.vue
+++ b/src/views/sidebar/components/TheSidebar.vue
@@ -167,7 +167,7 @@ export default {
       return `${diff.hours()}h ${diff.minutes()}m left`
     },
     incompleteTodos () {
-      return this.$store.state.todos.filter(t => !t.completed)
+      return this.$store.state.todos.todos.filter(t => !t.completed)
     },
     allTodos () {
       return this.$store.state.todos.todos


### PR DESCRIPTION
Caused by calling `filter` on `this.$store.state.todos` instead of `this.$store.state.todos.todos` in my last commit. Not sure why no error messages appeared.