### PR TITLE
Added nullish checks for MongoDB responses

### DIFF
--- a/server/api/announcements/announcements.controller.js
+++ b/server/api/announcements/announcements.controller.js
@@ -90,7 +90,9 @@ async function deleteAnnouncement (ctx) {
     _id: announcementID
   })
 
-  if (!deletedAnnouncement) return ctx.notFound('Couldn\'t find the announcement!')
+  if (!deletedAnnouncement) {
+    return ctx.notFound('Couldn\'t find the announcement!')
+  }
 
   deletedAnnouncement.remove()
 

--- a/server/api/blocks/blocks.controller.js
+++ b/server/api/blocks/blocks.controller.js
@@ -130,7 +130,7 @@ async function editWorkBlock (ctx) {
 
   if (!editedBlock) {
     logger.error(`Could not find work block ${blockID} for ${ctx.state.user.identifier} to edit`)
-    return ctx.notFound(`Could'nt find work block to edit!`)
+    return ctx.notFound(`Couldn't find work block to edit!`)
   }
 
   editedBlock.set(ctx.request.body)

--- a/server/api/courses/courses.controller.js
+++ b/server/api/courses/courses.controller.js
@@ -43,6 +43,10 @@ async function updateCourse (ctx) {
       _student: ctx.state.user._id
     })
 
+    if (!course) {
+      return ctx.notFound('A course that matches this criteria could not be found.')
+    }
+
     const forbiddenProperties = ['_id', '_student', 'crn', 'originalTitle']
     if (forbiddenProperties.some(prop => prop in forbiddenProperties)) {
       throw new Error(

--- a/server/api/quicklinks/quicklinks.controller.js
+++ b/server/api/quicklinks/quicklinks.controller.js
@@ -87,8 +87,11 @@ async function deleteQuickLink (ctx) {
     _id: quickLinkID
   })
 
-  deletedQuickLink.remove()
+  if (!deletedQuickLink) {
+    return ctx.notFound('No quick link could be found matching this criteria.')
+  }
 
+  deletedQuickLink.remove()
   logger.info(`Deleted quick link for ${ctx.state.user.identifier}`)
   ctx.ok({ deletedQuickLink })
 }

--- a/server/api/todos/todos.controller.js
+++ b/server/api/todos/todos.controller.js
@@ -65,16 +65,19 @@ async function updateTodo (ctx) {
     _student: ctx.state.user._id
   })
 
-  if (todo) {
-    if (typeof text === 'string') {
-      todo.text = text
-    }
-    if (typeof completed === 'number' || completed === null) {
-      todo.completed = completed
-    }
-
-    todo.save()
+  if (!todo) {
+    return ctx.notFound('No todo item could be found that matches this criteria.')
   }
+
+  if (typeof text === 'string') {
+    todo.text = text
+  }
+  if (typeof completed === 'number' || completed === null) {
+    todo.completed = completed
+  }
+
+  todo.save()
+
   ctx.ok({ todo })
 }
 
@@ -90,6 +93,10 @@ async function deleteTodo (ctx) {
     _id: todoID,
     _student: ctx.state.user._id
   })
+
+  if (!deletedTodo) {
+    return ctx.notFound('No todo item could be found that matches this criteria.')
+  }
 
   deletedTodo.remove()
 

--- a/server/api/unavailabilities/unavailabilities.controller.js
+++ b/server/api/unavailabilities/unavailabilities.controller.js
@@ -79,6 +79,10 @@ async function updateUnavailability (ctx) {
       _student: ctx.state.user._id
     })
 
+    if (!updatedUnavailability) {
+      return ctx.notFound('No unavailability could be found that matches that criteria.')
+    }
+
     updatedUnavailability.set(ctx.request.body)
 
     await updatedUnavailability.save()
@@ -105,6 +109,10 @@ async function removeUnavailability (ctx) {
     _id: unavailabilityID,
     _student: ctx.state.user._id
   })
+
+  if (!deletedUnavailability) {
+    return ctx.notFound('No unavailability could be found that matches that criteria.')
+  }
 
   deletedUnavailability.remove()
 

--- a/src/views/sidebar/components/TheSidebar.vue
+++ b/src/views/sidebar/components/TheSidebar.vue
@@ -167,7 +167,7 @@ export default {
       return `${diff.hours()}h ${diff.minutes()}m left`
     },
     incompleteTodos () {
-      return this.$store.state.todos.filter(t => !t.completed)
+      return this.$store.state.todos.todos.filter(t => !t.completed)
     },
     allTodos () {
       return this.$store.state.todos.todos


### PR DESCRIPTION
Some API controllers were not checking if documents were actually found or not after `findOne` searches, leading to vague 500 errors if there is a discrepancy between the client and the server, or if the user improperly uses the API. This avoids this issue by responding with 404 if a document is not found before attempting to perform actions on it (e.g. `remove()`).