### PR TITLE
Fixed issue #436

### DIFF
--- a/src/views/account/AccountSetupUnavailability.vue
+++ b/src/views/account/AccountSetupUnavailability.vue
@@ -236,7 +236,7 @@ export default {
       end = moment(end)
 
       this.$buefy.dialog.prompt({
-        message: `What are you doing ${start.format('h:mma')} to ${start.format(
+        message: `What are you doing ${start.format('h:mma')} to ${end.format(
           'h:mma'
         )} on ${start.format('dddd')}?`,
         confirmText: 'Add Block',


### PR DESCRIPTION
Fixed issue #436

Fixed "What are you doing from {start} to {start}" pop up message for Unavailable Time Block by replacing second {start} variable with the correct {end} time variable.
