### PR TITLE
fixed 481

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "vue-analytics": "^5.17.2",
     "vue-knob-control": "^1.6.0",
     "vue-markdown": "^2.2.4",
+    "vue-poll": "^0.1.8",
     "vue-progressbar": "^0.7.5",
     "vue-router": "^3.1.2",
     "vue-socket.io-extended": "^4.0.0",

--- a/src/views/components/TheHeader.vue
+++ b/src/views/components/TheHeader.vue
@@ -216,7 +216,7 @@
         <a
           v-if="loggedIn"
           class="navbar-item"
-          :title="`There are ${onlineUsers.length} users online.`"
+          :title="`There ${onlineUsers.length > 1 ? 'are' : 'is'} ${onlineUsers.length} ${onlineUsers.length > 1 ? 'users' : 'user'} online.`"
           @click="rickRollModalOpen = true"
         >
           <b-tag type="is-primary">{{ onlineUsers.length }} online</b-tag>


### PR DESCRIPTION
Fixes #481

## Proposed Changes
Hovering over online will now display the proper grammar. i.e. when 1 user is online, it will say: "There is 1 user online" and when there are > 1 user it will say: "There are _ users online".
