### PR TITLE
Fixed issue 496

### DIFF
--- a/src/views/assessments/AssessmentsUpcoming.vue
+++ b/src/views/assessments/AssessmentsUpcoming.vue
@@ -233,11 +233,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.panel-heading {
-  border-left: 1px solid #2e3b59;
-  border-right:1px solid #2e3b59;
-  border-top:1px solid #2e3b59;
-}
 .key-heading {
   span.key.courseCRN {
     cursor: pointer;


### PR DESCRIPTION
Fixes # Group by course border

## Proposed Changes
The panels of Upcoming Coursework > Group by Course no longer have dark upper border. I removed the .panel-heading{ } which contained the border attributes.
