### PR TITLE
Fixed bug where classes ended too early

### DIFF
--- a/src/mixins/fullcalendar.js
+++ b/src/mixins/fullcalendar.js
@@ -14,7 +14,7 @@ export default {
     eventRender ({ event, el, view }) {
       if (event.extendedProps.eventType === 'course') {
         // Prevent classes from showing up after the end of classes
-        if (moment(event.start).isAfter(this.currentTerm.classesEnd)) {
+        if (moment(event.start).isAfter(moment(this.currentTerm.classesEnd).endOf('day'))) {
           return false
         }
       }


### PR DESCRIPTION
Fixes #530 

## Proposed Changes
<!-- Here you want to explain what changes you made as best you can. -->
- Fixed bug where Wednesday didn't show any classes even though there's still class that day, because we were using `currentTerm.classesEnd` rather than `moment(this.currentTerm.classesEnd).endOf('day')`
- 
- 
