### PR TITLE
Fix issue with course scheduler conflicts

### DIFF
--- a/src/views/scheduling/SchedulePlannerPage.vue
+++ b/src/views/scheduling/SchedulePlannerPage.vue
@@ -382,6 +382,7 @@ export default {
       return this.includeConflicts ? possible : possible.filter(this.hasNoConflicts)
     },
     selectedSchedule () {
+      if (!this.possibleSchedules.length) return []
       return this.possibleSchedules[this.selectedScheduleIndex]
     },
     selectedSubjectCourses () {
@@ -429,6 +430,8 @@ export default {
       }
     },
     hasNoConflicts (crns) {
+      if (crns === undefined || !crns.length) return false
+
       const periods = this.selectedSections.filter(section => crns.includes(section.crn)).map(section => section.periods).flat()
       // Look for overlaps
       for (const period1 of periods) {


### PR DESCRIPTION
Fixes #611

## Proposed Changes
Changes to SchedulePlannerPage.vue:
- Line 433: periods is dependant on crns and will error if undefined; conflict when crns is empty; both cases should return false to indicate conflict
- Line 385: Avoid Line 386; accessing index on empty array; return empty array
